### PR TITLE
Solution6: Prevent IE from Opening Untrusted HTML with helmet.ieNoOpen()

### DIFF
--- a/myApp.js
+++ b/myApp.js
@@ -15,6 +15,11 @@ app.use(helmet.xssFilter())
 //Solution5: Avoid Inferring the Response MIME Type with helmet.noSniff()
 app.use(helmet.noSniff())
 
+//Solution6: Prevent IE from Opening Untrusted HTML with helmet.ieNoOpen()
+app.use(helmet.ieNoOpen())
+
+
+
 module.exports = app
 
 const api = require('./server.js')


### PR DESCRIPTION
This middleware sets the X-Download-Options header to noopen. This will prevent IE users from executing downloads in the trusted site's context.

Use the helmet.ieNoOpen() method on your server.