### PR TITLE
Solution7: Ask Browsers to Access Your Site via HTTPS Only with helmet.hsts()

### DIFF
--- a/myApp.js
+++ b/myApp.js
@@ -18,6 +18,9 @@ app.use(helmet.noSniff())
 //Solution6: Prevent IE from Opening Untrusted HTML with helmet.ieNoOpen()
 app.use(helmet.ieNoOpen())
 
+//Solution7: Ask Browsers to Access Your Site via HTTPS Only with helmet.hsts()
+const timeInSeconds = 90 * 24 * 60 * 60
+app.use(helmet.hsts({maxAge: timeInSeconds, force: true}))
 
 
 module.exports = app


### PR DESCRIPTION
Configure helmet.hsts() to use HTTPS for the next 90 days. Pass the config object {maxAge: timeInSeconds, force: true}. You can create a variable ninetyDaysInSeconds = 90*24*60*60; to use for the timeInSeconds. Gitpod already has hsts enabled. To override its settings you need to set the field "force" to true in the config object. We will intercept and restore the Gitpod header, after inspecting it for testing.

Note: Configuring HTTPS on a custom website requires the acquisition of a domain, and an SSL/TLS Certificate.