### PR TITLE
Solution8: Disable DNS Prefetching with helmet.dnsPrefetchControl()

### DIFF
--- a/myApp.js
+++ b/myApp.js
@@ -22,6 +22,9 @@ app.use(helmet.ieNoOpen())
 const timeInSeconds = 90 * 24 * 60 * 60
 app.use(helmet.hsts({maxAge: timeInSeconds, force: true}))
 
+//Solution8: Disable DNS Prefetching with helmet.dnsPrefetchControl()
+app.use(helmet.dnsPrefetchControl())
+
 
 module.exports = app
 


### PR DESCRIPTION
If you have high security needs you can disable DNS prefetching, at the cost of a performance penalty.

Use the helmet.dnsPrefetchControl() method on your server.