### PR TITLE
Solution9: Disable Client-Side Caching with helmet.noCache()

### DIFF
--- a/myApp.js
+++ b/myApp.js
@@ -25,6 +25,9 @@ app.use(helmet.hsts({maxAge: timeInSeconds, force: true}))
 //Solution8: Disable DNS Prefetching with helmet.dnsPrefetchControl()
 app.use(helmet.dnsPrefetchControl())
 
+//Solution9: Disable Client-Side Caching with helmet.noCache()
+app.use(helmet.noCache())
+
 
 module.exports = app
 


### PR DESCRIPTION
Caching has performance benefits, which you will lose, so only use this option when there is a real need.

Use the helmet.noCache() method on your server.