### PR TITLE
Solution10: Set a Content Security Policy with helmet.contentSecurityPolicy()

### DIFF
--- a/myApp.js
+++ b/myApp.js
@@ -28,6 +28,12 @@ app.use(helmet.dnsPrefetchControl())
 //Solution9: Disable Client-Side Caching with helmet.noCache()
 app.use(helmet.noCache())
 
+//Solution10: Set a Content Security Policy with helmet.contentSecurityPolicy()
+app.use(helmet.contentSecurityPolicy({ directives: { 
+    defaultSrc: ["'self'"], scriptSrc: ["'self'", "trusted-cdn.com"] 
+  }} 
+))
+
 
 module.exports = app
 


### PR DESCRIPTION
In this exercise, use helmet.contentSecurityPolicy(). Configure it by adding a directives object. In the object, set the defaultSrc to ["'self'"] (the list of allowed sources must be in an array), in order to trust only your website address by default. Also set the scriptSrc directive so that you only allow scripts to be downloaded from your website ('self'), and from the domain 'trusted-cdn.com'.

Hint: in the 'self' keyword, the single quotes are part of the keyword itself, so it needs to be enclosed in double quotes to be working.